### PR TITLE
Allow player to restart level.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -28,6 +28,14 @@ using LevelArray =
 
 class Level {
 private:
+  int height, width;
+  int player_xInit, player_yInit;
+  int player_x, player_y;
+  Tile player_replaceTileInit;
+  Tile player_replaceTile;
+  LevelArray gridInit;
+  LevelArray grid;
+
   bool MoveBox(int pos_x, int pos_y, int dir_x, int dir_y, Tile currentTile) {
     int target_x{pos_x + dir_x};
     int target_y{pos_y + dir_y};
@@ -53,13 +61,10 @@ private:
   }
 
 public:
-  int height, width;
-  int player_x, player_y;
-  Tile player_replaceTile;
-  LevelArray grid;
-
   Level()
-      : height{0}, width{0}, player_x{0}, player_y{0},
+      : height{0}, width{0}, player_xInit{0}, player_yInit{0},
+        player_replaceTileInit(Tile::none), gridInit{Tile::none},
+        player_x{0}, player_y{0},
         player_replaceTile(Tile::none), grid{Tile::none} {}
 
   void AddRow(std::string row_string) {
@@ -69,15 +74,22 @@ public:
 
     int x{0};
     for (char c : row_string) {
-      grid[height][x] = charmap.at(c);
+      gridInit[height][x] = charmap.at(c);
       if (c == '@' || c == '+') {
-        player_x = x;
-        player_y = height;
-        if (c == '+') player_replaceTile = Tile::goal;
+        player_xInit = x;
+        player_yInit = height;
+        if (c == '+') player_replaceTileInit = Tile::goal;
       }
       x++;
     }
     height++;
+  }
+
+  void InitGrid() {
+    player_x = player_xInit;
+    player_y = player_yInit;
+    player_replaceTile = player_replaceTileInit;
+    grid = gridInit;
   }
 
   void Draw() {
@@ -136,6 +148,8 @@ int main() {
   std::string rowString{};
   while (std::getline(levelFile, rowString))
     level.AddRow(rowString);
+
+  level.InitGrid();
 
   InitWindow(1000, 800, "raygui test");
   SetTargetFPS(60);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -166,6 +166,10 @@ int main() {
       level.MovePlayer(0, -1);
     }
 
+    if (IsKeyPressed(KEY_R)) {
+      level.InitGrid();
+    }
+
     BeginDrawing();
     level.Draw();
     EndDrawing();


### PR DESCRIPTION
### Summary

- Allows the player to restart the current level by pressing the `r` key.
- Refactors the Level class to store the initial state of the level, facilitating the restart behaviour

Resolves #3 

### Description

Previously the only way to reset a level was by restarting the program. This is obviously not an ideal way to do this so a restart function was necessary. The key change to allow this to happen was to update the Level object to store the initial state of the level. Before this the level grid was loaded directly from the .txt file, and resetting the level would therefore have required reloading from this file.
The solution chosen was to instead load all initial level state (grid layout, player position, etc.) into another set of variables (`player_xInit`, `gridInit`, etc.), and then initialise the actual state that the player interacts with from these variables. The level can then be re-initialised to this state at any time.

One approach that was briefly considered was to store the current play grid and any variables that are manipulated by the player in a separate class, with the `Level` class containing only the static, initial state of the level. However it was decided that there would be little benefit to splitting this out at this stage. However this might be something to consider if/when the complexity of the `Level` class grows.