### PR TITLE
refactor: Move graphics calls out of Level class

### DIFF
--- a/src/graphics.cpp
+++ b/src/graphics.cpp
@@ -1,0 +1,11 @@
+#include "graphics.hpp"
+
+void DrawLevel(LevelArray level, int width, int height) {
+  for (int x = 0; x < width; x++) {
+    for (int y = 0; y < height; y++) {
+      DrawRectangle(x * constants::tile_width, y * constants::tile_height,
+                    constants::tile_width, constants::tile_height,
+                    tilemap.at(level[y][x]));
+    }
+  }
+}

--- a/src/graphics.hpp
+++ b/src/graphics.hpp
@@ -1,0 +1,8 @@
+#ifndef GRAPHICS_HPP
+#define GRAPHICS_HPP
+
+#include "level.hpp"
+
+void DrawLevel(LevelArray level, int width, int height);
+
+#endif

--- a/src/level.cpp
+++ b/src/level.cpp
@@ -2,22 +2,15 @@
 
 #include <map>
 
-#include "raylib.h"
-
 const std::map<char, Tile> charmap{
     {' ', Tile::none},       {'#', Tile::wall}, {'$', Tile::box},
     {'@', Tile::player},     {'.', Tile::goal}, {'*', Tile::box_goal},
     {'+', Tile::player_goal}};
 
-const std::map<Tile, Color> tilemap{
-    {Tile::none, LIGHTGRAY},    {Tile::wall, DARKGRAY}, {Tile::box, BROWN},
-    {Tile::player, RED},        {Tile::goal, YELLOW},   {Tile::box_goal, GREEN},
-    {Tile::player_goal, ORANGE}};
-
 Level::Level()
-    : height{0}, width{0}, player_xInit{0}, player_yInit{0},
+    : height_{0}, width_{0}, player_xInit{0}, player_yInit{0},
       player_replaceTileInit(Tile::none), gridInit{Tile::none}, player_x{0},
-      player_y{0}, player_replaceTile(Tile::none), grid{Tile::none} {}
+      player_y{0}, player_replaceTile(Tile::none), grid_{Tile::none} {}
 
 bool Level::MoveBox(int pos_x, int pos_y, int dir_x, int dir_y,
                     Tile currentTile) {
@@ -31,59 +24,49 @@ bool Level::MoveBox(int pos_x, int pos_y, int dir_x, int dir_y,
     replaceTile = Tile::none;
   }
 
-  if (grid[target_y][target_x] == Tile::none) {
-    grid[target_y][target_x] = Tile::box;
-  } else if (grid[target_y][target_x] == Tile::goal) {
-    grid[target_y][target_x] = Tile::box_goal;
+  if (grid_[target_y][target_x] == Tile::none) {
+    grid_[target_y][target_x] = Tile::box;
+  } else if (grid_[target_y][target_x] == Tile::goal) {
+    grid_[target_y][target_x] = Tile::box_goal;
   } else {
     return false;
   }
 
-  grid[pos_y][pos_x] = replaceTile;
+  grid_[pos_y][pos_x] = replaceTile;
 
   return true;
 }
 
 void Level::AddRow(std::string row_string) {
-  if (row_string.size() > width) {
-    width = row_string.size();
+  if (row_string.size() > width_) {
+    width_ = row_string.size();
   }
 
   int x{0};
   for (char c : row_string) {
-    gridInit[height][x] = charmap.at(c);
+    gridInit[height_][x] = charmap.at(c);
     if (c == '@' || c == '+') {
       player_xInit = x;
-      player_yInit = height;
+      player_yInit = height_;
       if (c == '+')
         player_replaceTileInit = Tile::goal;
     }
     x++;
   }
-  height++;
+  height_++;
 }
 
 void Level::InitGrid() {
   player_x = player_xInit;
   player_y = player_yInit;
   player_replaceTile = player_replaceTileInit;
-  grid = gridInit;
-}
-
-void Level::Draw() {
-  for (int x = 0; x < width; x++) {
-    for (int y = 0; y < height; y++) {
-      DrawRectangle(x * constants::tile_width, y * constants::tile_height,
-                    constants::tile_width, constants::tile_height,
-                    tilemap.at(grid[y][x]));
-    }
-  }
+  grid_ = gridInit;
 }
 
 void Level::MovePlayer(int dir_x, int dir_y) {
   int target_x{player_x + dir_x};
   int target_y{player_y + dir_y};
-  Tile target_tile{grid[target_y][target_x]};
+  Tile target_tile{grid_[target_y][target_x]};
 
   if (target_tile == Tile::box || target_tile == Tile::box_goal) {
     if (!MoveBox(target_x, target_y, dir_x, dir_y, target_tile))
@@ -100,12 +83,12 @@ void Level::MovePlayer(int dir_x, int dir_y) {
     target_replaceTile = Tile::player_goal;
   }
 
-  grid[player_y][player_x] = player_replaceTile;
+  grid_[player_y][player_x] = player_replaceTile;
 
   // If a box was pushed above, the value of target_tile is no longer valid,
   // so we need to re-access the target destination to set player_replaceTile
-  player_replaceTile = grid[target_y][target_x];
-  grid[target_y][target_x] = target_replaceTile;
+  player_replaceTile = grid_[target_y][target_x];
+  grid_[target_y][target_x] = target_replaceTile;
   player_x = target_x;
   player_y = target_y;
 

--- a/src/level.hpp
+++ b/src/level.hpp
@@ -3,31 +3,41 @@
 
 #include <array>
 #include <string>
+#include <map>
 
 #include "constants.hpp"
+#include "raylib.h"
 
 enum class Tile { none, wall, box, player, goal, box_goal, player_goal };
 
 using LevelArray =
     std::array<std::array<Tile, constants::max_width>, constants::max_height>;
 
+const std::map<Tile, Color> tilemap{
+    {Tile::none, LIGHTGRAY},    {Tile::wall, DARKGRAY}, {Tile::box, BROWN},
+    {Tile::player, RED},        {Tile::goal, YELLOW},   {Tile::box_goal, GREEN},
+    {Tile::player_goal, ORANGE}};
+
 class Level {
 private:
-  int height, width;
+  int height_, width_;
   int player_xInit, player_yInit;
   int player_x, player_y;
   Tile player_replaceTileInit;
   Tile player_replaceTile;
   LevelArray gridInit;
-  LevelArray grid;
+  LevelArray grid_;
 
   bool MoveBox(int pos_x, int pos_y, int dir_x, int dir_y, Tile currentTile);
 
 public:
+  LevelArray grid() const { return grid_; };
+  int height() const { return height_; };
+  int width() const { return width_; };
+
   Level();
   void AddRow(std::string row_string);  
   void InitGrid();
-  void Draw();
   void MovePlayer(int dir_x, int dir_y);
 };
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -10,6 +10,7 @@
 
 #include "level.hpp"
 #include "loading.hpp"
+#include "graphics.hpp"
 
 int main(int argc, char* argv[]) {
   Level level{};
@@ -65,7 +66,7 @@ int main(int argc, char* argv[]) {
     }
 
     BeginDrawing();
-    level.Draw();
+    DrawLevel(level.grid(), level.width(), level.height());
     EndDrawing();
   }
 


### PR DESCRIPTION
### Summary

- The calls to the raylib graphics functions are now handled in a function completely removed from the Level class

Resolves #12 

### Description

This is essential just a 1-to-1 copy of the Level::Draw method into a new function, which naturally requires all of the relevant Level data (grid, width and height) to be passed into. 

For a little while I was sat here wondering if this was actually worth doing because at this scale of program, the complexity is really the same, and if anything having to add a bunch of getters to the Level class so that we can pass that data into the new function makes things more complex. Ultimately though I have come to the conclusion that this is worth doing because for any program more complex than this we would have more than a single object containing our state data, so in the general case it would definitely be the best practice.
